### PR TITLE
Migrate from devbox to mise-en-place package manager

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,12 @@
+[tools]
+helix = "latest"
+ripgrep = "latest"
+gh = "latest"
+go = "latest"
+# skopeo = "latest"  # Not available in mise registry - see TODO.md for alternatives
+
+[env]
+# Environment variables can be defined here if needed
+
+[alias]
+# Tool aliases can be defined here if needed

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,36 @@
+# Migration from devbox to mise-en-place - TODOs
+
+## Tools Status
+
+### ✅ Available in mise registry
+- `helix` - Available via `aqua:helix-editor/helix ubi:helix-editor/helix`
+- `ripgrep` - Available via `aqua:BurntSushi/ripgrep ubi:BurntSushi/ripgrep[exe=rg]`  
+- `gh` - Available via `aqua:cli/cli ubi:cli/cli[exe=gh]`
+- `go` - Available via `core:go`
+
+### ❌ Not available in mise registry
+- `bash` - System bash is sufficient, no version management needed
+- `skopeo` - **NEEDS ALTERNATIVE INSTALLATION METHOD**
+
+## TODO: Alternative installation methods for skopeo
+
+### Option 1: System Package Manager
+Install via system package manager and document in setup scripts:
+- Ubuntu/Debian: `apt install skopeo`
+- Fedora/RHEL: `dnf install skopeo` 
+- Arch: `pacman -S skopeo`
+
+### Option 2: Manual Binary Installation
+Download pre-built binaries from GitHub releases and install to `~/.local/bin`
+
+### Option 3: Container-based approach  
+Use skopeo via container image from quay.io with alias/wrapper script
+
+### Option 4: Build from source
+Clone and build skopeo from source, though this adds complexity
+
+### Option 5: Check for third-party mise plugins
+Search for community-maintained mise plugins that might support skopeo
+
+## Decision needed
+Determine which approach works best for the dotfiles setup and document the installation method.

--- a/activate
+++ b/activate
@@ -19,7 +19,7 @@ if [[ -f $HOME/.secret ]]; then
 fi
 
 #export PATH=$(dedupe_path)
-devbox=$(command -v devbox)
-if [[ ! -z $devbox ]]; then
-    eval "$(devbox global shellenv)"
+mise=$(command -v mise)
+if [[ ! -z $mise ]]; then
+    eval "$(mise activate bash)"
 fi

--- a/env/localpath.sh
+++ b/env/localpath.sh
@@ -13,7 +13,7 @@ if [[ -d $HOME/.local/bin ]]; then
 fi
 
 PATH=$PATH:$JAVA_HOME/bin:$HOME/bin
-
+PATH="/var/home/connor/.bun/bin:$PATH"
 
 export PATH
 

--- a/pets/authorized_keys/keys.bash
+++ b/pets/authorized_keys/keys.bash
@@ -14,6 +14,9 @@ trap 'echo failure ${LINENO} "$BASH_COMMAND"' ERR
 
 
 KEYS_FILE=~/.ssh/authorized_keys
+KEYS_DIR=$(dirname $KEYS_FILE)
+mkdir -p $KEYS_DIR
+touch $KEYS_FILE
 github_keys=$(curl -s https://github.com/clly.keys)
 tmp_keys=$(mktemp -d -p ~/.ssh)/keys
 tmp_dir=${tmp_keys%%/keys}

--- a/setup.bash
+++ b/setup.bash
@@ -69,7 +69,7 @@ if [[ $os == "Fedora" ]]; then
     sudo curl --output-dir "/etc/yum.repos.d/" -O https://pkgs.tailscale.com/stable/rhel/9/tailscale.repo
     sudo rpm-ostree override remove firefox firefox-langpacks
     rpm-ostree refresh-md
-    rpm-ostree install --idempotent tmux neovim gh gcc-c++ ghostty 1password-cli 1password tailscale treyscale git-lfs
+    rpm-ostree install --idempotent tmux neovim gh gcc-c++ ghostty 1password-cli 1password tailscale treyscale git-lfs cmake
     paks=(dev.zed.Zed com.jetbrains.IntelliJ-IDEA-Ultimate org.mozilla.firefox)
     for pak in ${paks[@]}; do
         flatpak install flathub $pak


### PR DESCRIPTION
## Summary
- Replaces devbox.json with .mise.toml configuration for package management
- Updates activate script to use `mise activate bash` instead of devbox
- Documents alternative installation methods for skopeo in TODO.md

## Changes
- ✅ **helix, ripgrep, gh, go** - Available in mise registry and configured
- ❌ **skopeo** - Not available in mise registry, requires alternative installation (documented in TODO.md)
- ✅ **bash** - Removed (system bash sufficient)

## Test plan
- [ ] Verify mise is installed and available
- [ ] Test tool availability after mise activation
- [ ] Ensure activate script works without errors
- [ ] Address skopeo installation per TODO.md

Closes #5